### PR TITLE
Update format command to be compatible with python3

### DIFF
--- a/plugin/jacinto.vim
+++ b/plugin/jacinto.vim
@@ -72,7 +72,7 @@ function! s:Format()
         return
     endif
     let _file = expand('%:p')
-    let python_command = "import json; print json.dumps(json.loads(' '.join(open('" . _file . "'))) ,sort_keys=True, indent=2)"
+    let python_command = "import json; print(json.dumps(json.loads(' '.join(open('" . _file . "'))) ,sort_keys=True, indent=2))"
     let cmd = 'python -c "' . python_command . '"'
     let out = system(cmd)
 


### PR DESCRIPTION
- just use `print()` as a function instead of as a command. Tested and found to be working on python 3.6.1 and 2.7.12. 